### PR TITLE
Bundlers problem fixed

### DIFF
--- a/src/dfp/dfp.js
+++ b/src/dfp/dfp.js
@@ -256,6 +256,13 @@ googletag.cmd = googletag.cmd || [];
     }];
   }
 
+  /**
+   * In order to avoid local variable creation while using bundlers such as browserify
+   * or webpack googletag variable is set as global explicitly.
+   * @type {{}}
+   */
+  window.googletag = googletag;
+
   module.provider('dfp', ['GPT_LIBRARY_URL', dfpProvider]);
 
 // eslint-disable-next-line


### PR DESCRIPTION
Bundlers such as browserify and webpack creates a selfinvoking function in order to create a modular structure the `googletag` object didn't actually reach the global scope.

This pull request provides a way to explicitly set the `googletag` object.